### PR TITLE
Add Zirgen-based acceleration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ sha2 = { version = "0.10.6", optional = true, default-features = false, features
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
-risc0-circuit-bigint = { default-features = false, features = [ "bigint-dig-shim" ] }
-risc0-zkvm = { default-features = false }
+risc0-circuit-bigint = { git = "https://github.com/risc0/risc0", default-features = false, features = [ "bigint-dig-shim" ] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", default-features = false }
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
@@ -70,11 +70,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 opt-level = 2
 
 # TODO: Point to a version tag once necessary features have stabilized
-[patch.crates-io.risc0-circuit-bigint]
-git = "https://github.com/risc0/risc0"
-branch = "main"
-
-# TODO: Point to a version tag once necessary features have stabilized
-[patch.crates-io.risc0-zkvm]
-git = "https://github.com/risc0/risc0"
-branch = "main"
+[patch.'https://github.com/risc0/risc0.git']
+risc0-circuit-bigint = { git = "https://github.com/risc0/risc0", branch = "main" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,12 +69,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 [profile.dev]
 opt-level = 2
 
-# TODO: Point to a stable version once necessary features have stabilized
+# TODO: Point to a version tag once necessary features have stabilized
 [patch.crates-io.risc0-circuit-bigint]
 git = "https://github.com/risc0/risc0"
 branch = "main"
 
-# TODO: Point to a stable version once necessary features have stabilized
+# TODO: Point to a version tag once necessary features have stabilized
 [patch.crates-io.risc0-zkvm]
 git = "https://github.com/risc0/risc0"
 branch = "main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,5 +71,5 @@ opt-level = 2
 
 # TODO: Point to a version tag once necessary features have stabilized
 [patch.'https://github.com/risc0/risc0.git']
-risc0-circuit-bigint = { git = "https://github.com/risc0/risc0", branch = "main" }
-risc0-zkvm = { git = "https://github.com/risc0/risc0", branch = "main" }
+risc0-circuit-bigint = { git = "https://github.com/risc0/risc0", rev = "e0338f6ce66ac3eba780e045d25df94145a03399" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "e0338f6ce66ac3eba780e045d25df94145a03399" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,8 @@ sha2 = { version = "0.10.6", optional = true, default-features = false, features
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
-# TODO don't use local versions
-risc0-circuit-bigint = { path = "/Users/tzerrell/code/risc0/risc0/circuit/bigint", default-features = false, features = [ "bigint-dig-shim" ] }
-risc0-zkvm = { path = "/Users/tzerrell/code/risc0/risc0/zkvm", default-features = false }
+risc0-circuit-bigint = { default-features = false, features = [ "bigint-dig-shim" ] }
+risc0-zkvm = { default-features = false }
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
@@ -69,3 +68,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [profile.dev]
 opt-level = 2
+
+# TODO: Point to a stable version once necessary features have stabilized
+[patch.crates-io.risc0-circuit-bigint]
+git = "https://github.com/risc0/risc0"
+branch = "main"
+
+# TODO: Point to a stable version once necessary features have stabilized
+[patch.crates-io.risc0-zkvm]
+git = "https://github.com/risc0/risc0"
+branch = "main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ sha1 = { version = "0.10.5", optional = true, default-features = false, features
 sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
+# TODO don't use local versions
+risc0-circuit-bigint = { path = "/Users/tzerrell/code/risc0/risc0/circuit/bigint", default-features = false, features = [ "bigint-dig-shim" ] }
+risc0-zkvm = { path = "/Users/tzerrell/code/risc0/risc0/zkvm", default-features = false }
+
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
 hex-literal = "0.4.1"

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -11,9 +11,6 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::errors::{Error, Result};
 use crate::traits::{PrivateKeyParts, PublicKeyParts};
 
-#[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-use risc0_zkvm::guest::env;
-
 /// ⚠️ Raw RSA encryption of m with the public key. No padding is performed.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -26,10 +26,10 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
     #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
     {
         // If we're in the RISC Zero zkVM, try to use its RSA accelerator circuit
-        env::log("[TODO] `rsa_encrypt` start");
         if *key.e() == BigUint::new(vec!{65537}) {
-            // TODO: clean up error escalation
-            return Ok(risc0_circuit_bigint::rsa::modpow_65537(key.n(), m).expect("TODO"));
+            // TODO: Could escalate errors a bit more nicely
+            // (e.g. to fall through to non-accelerated version if error is safe for that)
+            return Ok(risc0_circuit_bigint::rsa::modpow_65537(key.n(), m).expect("Unable to run RSA accelerator"));
         }
         // Fall through when the exponent does not match the accelerator
     }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -14,7 +14,6 @@ use crate::traits::{PrivateKeyParts, PublicKeyParts};
 #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
 use risc0_zkvm::guest::env;
 
-
 /// ⚠️ Raw RSA encryption of m with the public key. No padding is performed.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
@@ -26,10 +25,11 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
     #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
     {
         // If we're in the RISC Zero zkVM, try to use its RSA accelerator circuit
-        if *key.e() == BigUint::new(vec!{65537}) {
+        if *key.e() == BigUint::new(vec![65537]) {
             // TODO: Could escalate errors a bit more nicely
             // (e.g. to fall through to non-accelerated version if error is safe for that)
-            return Ok(risc0_circuit_bigint::rsa::modpow_65537(key.n(), m).expect("Unable to run RSA accelerator"));
+            return Ok(risc0_circuit_bigint::rsa::modpow_65537(key.n(), m)
+                .expect("Unable to run RSA accelerator"));
         }
         // Fall through when the exponent does not match the accelerator
     }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -31,7 +31,7 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
             // TODO: clean up error escalation
             return Ok(risc0_circuit_bigint::rsa::modpow_65537(key.n(), m).expect("TODO"));
         }
-        // Fall through when the exponent does not match our accelerator
+        // Fall through when the exponent does not match the accelerator
     }
     Ok(m.modpow(key.e(), key.n()))
 }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -23,10 +23,8 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
     {
         // If we're in the RISC Zero zkVM, try to use its RSA accelerator circuit
         if *key.e() == BigUint::new(vec![65537]) {
-            // TODO: Could escalate errors a bit more nicely
-            // (e.g. to fall through to non-accelerated version if error is safe for that)
             return Ok(risc0_circuit_bigint::rsa::modpow_65537(m, key.n())
-                .expect("Unable to run RSA accelerator"));
+                .expect("Unexpected failure to run RSA accelerator"));
         }
         // Fall through when the exponent does not match the accelerator
     }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -28,7 +28,7 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
         if *key.e() == BigUint::new(vec![65537]) {
             // TODO: Could escalate errors a bit more nicely
             // (e.g. to fall through to non-accelerated version if error is safe for that)
-            return Ok(risc0_circuit_bigint::rsa::modpow_65537(key.n(), m)
+            return Ok(risc0_circuit_bigint::rsa::modpow_65537(m, key.n())
                 .expect("Unable to run RSA accelerator"));
         }
         // Fall through when the exponent does not match the accelerator

--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 pub use ::signature::{
     hazmat::{PrehashSigner, PrehashVerifier},
     DigestSigner, DigestVerifier, Error, Keypair, RandomizedDigestSigner, RandomizedSigner, Result,

--- a/src/pss/signature.rs
+++ b/src/pss/signature.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 pub use ::signature::{
     hazmat::{PrehashSigner, PrehashVerifier},
     DigestSigner, DigestVerifier, Error, Keypair, RandomizedDigestSigner, RandomizedSigner, Result,


### PR DESCRIPTION
Make use of the RSA acceleration from https://github.com/risc0/risc0/pull/2481 when run in the RISC Zero guest.

~Can't land until https://github.com/risc0/risc0/pull/2481 lands.~