### PR TITLE
Use the new RSA extern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,6 @@ sha1 = { version = "0.10.5", optional = true, default-features = false, features
 sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
-[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
-risc0-circuit-bigint = { git = "https://github.com/risc0/risc0", default-features = false, features = [ "bigint-dig-shim" ] }
-risc0-zkvm = { git = "https://github.com/risc0/risc0", default-features = false }
-
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
 hex-literal = "0.4.1"
@@ -68,8 +64,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [profile.dev]
 opt-level = 2
-
-# TODO: Point to a version tag once necessary features have stabilized
-[patch.'https://github.com/risc0/risc0.git']
-risc0-circuit-bigint = { git = "https://github.com/risc0/risc0", rev = "e0338f6ce66ac3eba780e045d25df94145a03399" }
-risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "e0338f6ce66ac3eba780e045d25df94145a03399" }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -18,6 +18,72 @@ extern "Rust" {
     fn todo_test_types(test: &Vec<u32>) -> Result<Vec<u32>>;
 }
 
+// TODO: Cleaner import?
+// From risc0_zkvm_platform::syscall::rsa::WIDTH_WORDS
+const RSA_WIDTH_WORDS: usize = 96;
+
+extern "C" {
+    // TODO: risc0_zkvm_platform::syscall::rsa::WIDTH_WORDS instead of magic # 96
+    fn sys_rsa(
+        recv_buf: *mut [u32; RSA_WIDTH_WORDS],
+        in_base: *const [u32; RSA_WIDTH_WORDS],
+        in_modulus: *const [u32; RSA_WIDTH_WORDS],
+    );
+    fn sys_rsa_and_prove(  // TODO: Better name
+        recv_buf: *mut [u32; RSA_WIDTH_WORDS],  // TODO nicer constant
+        in_base: *const [u32; RSA_WIDTH_WORDS],
+        in_modulus: *const [u32; RSA_WIDTH_WORDS],
+    );
+}
+
+// TODO: Wraps a syscall, doesn't prove anything (yet, growth mindset!)
+fn nondet_modpow_65537(base: &BigUint, modulus: &BigUint) -> BigUint {
+    // Ensure inputs fill an even number of words
+    let mut base = base.to_bytes_le();
+    if base.len() % 4 != 0 {
+        base.resize(base.len() + (4 - (base.len() % 4)), 0);
+    }
+    let mut modulus = modulus.to_bytes_le();
+    if modulus.len() % 4 != 0 {
+        modulus.resize(modulus.len() + (4 - (modulus.len() % 4)), 0);
+    }
+    let base: [u32; RSA_WIDTH_WORDS] = base.chunks(4)
+        .map(|word| u32::from_le_bytes(word.try_into().unwrap()))
+        .collect::<Vec<u32>>()
+        .try_into()
+        .unwrap();
+    let modulus: [u32; RSA_WIDTH_WORDS] = modulus.chunks(4)
+        .map(|word| u32::from_le_bytes(word.try_into().unwrap()))
+        .collect::<Vec<u32>>()
+        .try_into()
+        .unwrap();
+    const fn zero() -> u32 {
+        0
+    }
+    let mut result = [zero(); RSA_WIDTH_WORDS];
+    // TODO: doc unsafe
+    unsafe {
+        // sys_rsa(&mut result, &base, &modulus);
+        sys_rsa_and_prove(&mut result, &base, &modulus);
+    }
+    return BigUint::from_slice(&result);
+    
+
+
+
+    
+                        // let mut base_vec = Vec::new();
+                        // for word in base.chunks(4) {
+                        //     let word: [u8; 4] = word.try_into()?;
+                        //     base_vec.push(u32::from_le_bytes(word));
+                        // }
+
+
+
+
+    // return base.clone();  // TODO: Just for testing not correct
+}
+
 
 fn todo_patch_types_modpow(base: &BigUint, modulus: &BigUint) -> BigUint {
     // Ensure inputs fill an even number of words
@@ -62,7 +128,10 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
         // If we're in the RISC Zero zkVM, try to use its RSA accelerator circuit
         if *key.e() == BigUint::new(vec![65537]) {
             unsafe {
-                return Ok(todo_patch_types_modpow(m, key.n()));
+                // TODO: This one isn't proving anything!
+                return Ok(nondet_modpow_65537(m, key.n()));
+
+                // return Ok(todo_patch_types_modpow(m, key.n()));
 
                 // return Ok(modpow_65537(m, key.n())
                 //     .expect("Unexpected failure to run RSA accelerator"));

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -18,7 +18,7 @@ const WIDTH_WORDS: usize = 96;
 
 #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
 extern "C" {
-    fn sys_rsa_and_prove(  // TODO: Better name
+    fn modpow_65537(
         recv_buf: *mut [u32; WIDTH_WORDS],
         in_base: *const [u32; WIDTH_WORDS],
         in_modulus: *const [u32; WIDTH_WORDS],
@@ -50,9 +50,9 @@ fn risc0_modpow_65537(base: &BigUint, modulus: &BigUint) -> BigUint {
         0
     }
     let mut result = [zero(); WIDTH_WORDS];
-    // TODO: doc unsafe
+    // Safety: Parameters are dereferenceable & aligned
     unsafe {
-        sys_rsa_and_prove(&mut result, &base, &modulus);
+        modpow_65537(&mut result, &base, &modulus);
     }
     return BigUint::from_slice(&result);
 }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -46,10 +46,7 @@ fn risc0_modpow_65537(base: &BigUint, modulus: &BigUint) -> BigUint {
         .collect::<Vec<u32>>()
         .try_into()
         .unwrap();
-    const fn zero() -> u32 {
-        0
-    }
-    let mut result = [zero(); WIDTH_WORDS];
+    let mut result = [0u32; WIDTH_WORDS];
     // Safety: Parameters are dereferenceable & aligned
     unsafe {
         modpow_65537(&mut result, &base, &modulus);

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -12,7 +12,7 @@ use crate::errors::{Error, Result};
 use crate::traits::{PrivateKeyParts, PublicKeyParts};
 
 extern "Rust" {
-    todo_test_fn(x: u32) -> u32;
+    fn modpow_65537(base: &BigUint, modulus: &BigUint) -> Result<BigUint>;
 }
 
 /// ⚠️ Raw RSA encryption of m with the public key. No padding is performed.
@@ -27,9 +27,9 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
     {
         // If we're in the RISC Zero zkVM, try to use its RSA accelerator circuit
         if *key.e() == BigUint::new(vec![65537]) {
-            assert_eq!(todo_test_fn(3), 0);
-            // return Ok(risc0_circuit_bigint::rsa::modpow_65537(m, key.n())
-            //     .expect("Unexpected failure to run RSA accelerator"));
+            unsafe {
+                return Ok(modpow_65537(m, key.n()).expect("Unexpected failure to run RSA accelerator"));
+            }
         }
         // Fall through when the exponent does not match the accelerator
     }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -28,7 +28,8 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
         // If we're in the RISC Zero zkVM, try to use its RSA accelerator circuit
         if *key.e() == BigUint::new(vec![65537]) {
             unsafe {
-                return Ok(modpow_65537(m, key.n()).expect("Unexpected failure to run RSA accelerator"));
+                return Ok(modpow_65537(m, key.n())
+                    .expect("Unexpected failure to run RSA accelerator"));
             }
         }
         // Fall through when the exponent does not match the accelerator

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -41,12 +41,14 @@ fn risc0_modpow_65537(base: &BigUint, modulus: &BigUint) -> BigUint {
     if modulus.len() % 4 != 0 {
         modulus.resize(modulus.len() + (4 - (modulus.len() % 4)), 0);
     }
-    let base: [u32; WIDTH_WORDS] = base.chunks(4)
+    let base: [u32; WIDTH_WORDS] = base
+        .chunks(4)
         .map(|word| u32::from_le_bytes(word.try_into().unwrap()))
         .collect::<Vec<u32>>()
         .try_into()
         .unwrap();
-    let modulus: [u32; WIDTH_WORDS] = modulus.chunks(4)
+    let modulus: [u32; WIDTH_WORDS] = modulus
+        .chunks(4)
         .map(|word| u32::from_le_bytes(word.try_into().unwrap()))
         .collect::<Vec<u32>>()
         .try_into()

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -11,6 +11,10 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::errors::{Error, Result};
 use crate::traits::{PrivateKeyParts, PublicKeyParts};
 
+extern "Rust" {
+    todo_test_fn(x: u32) -> u32;
+}
+
 /// ⚠️ Raw RSA encryption of m with the public key. No padding is performed.
 ///
 /// # ☢️️ WARNING: HAZARDOUS API ☢️
@@ -23,8 +27,9 @@ pub fn rsa_encrypt<K: PublicKeyParts>(key: &K, m: &BigUint) -> Result<BigUint> {
     {
         // If we're in the RISC Zero zkVM, try to use its RSA accelerator circuit
         if *key.e() == BigUint::new(vec![65537]) {
-            return Ok(risc0_circuit_bigint::rsa::modpow_65537(m, key.n())
-                .expect("Unexpected failure to run RSA accelerator"));
+            assert_eq!(todo_test_fn(3), 0);
+            // return Ok(risc0_circuit_bigint::rsa::modpow_65537(m, key.n())
+            //     .expect("Unexpected failure to run RSA accelerator"));
         }
         // Fall through when the exponent does not match the accelerator
     }

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -26,6 +26,11 @@ extern "C" {
 }
 
 #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+/// Provides acceleration for ModPow (exponent 65537) in the RISC Zero zkVM
+///
+/// Note that to use this, a dependency on `risc0-circuit-bigint` must be added
+/// to the RISC Zero zkVM guest code calling this even if it is not otherwise
+/// necessary.
 fn risc0_modpow_65537(base: &BigUint, modulus: &BigUint) -> BigUint {
     // Ensure inputs fill an even number of words
     let mut base = base.to_bytes_le();


### PR DESCRIPTION
Make the necessary updates to use the new RSA extern from https://github.com/risc0/risc0/pull/2487

There's a bit of a sharp edge, where the guest crate call this needs to be sure to depend on `risc0-circuit-bigint` ~and to make a call directly to `modpow_65537` from the `rsa` module of that crate (even if only in a dead code function that's never used) so the linker doesn't optimize it away~. We should either document or fix this sharp edge.