### PR TITLE
Update bigint2 impl with 4096 bit support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "risc0-bigint2"
 version = "1.3.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?rev=c724cc14e316ff7bfae146bbbf2676515dac2a46#c724cc14e316ff7bfae146bbbf2676515dac2a46"
+source = "git+https://github.com/risc0/risc0?rev=ead10a316d6850a2a3e1332a00c7c432292313ab#ead10a316d6850a2a3e1332a00c7c432292313ab"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint-dig",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,8 +471,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.3.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?rev=ead10a316d6850a2a3e1332a00c7c432292313ab#ead10a316d6850a2a3e1332a00c7c432292313ab"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c185a3bfaee681eed5bfac1440128184bf0b6544c345fb4d7bd4317c909fb"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint-dig",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,11 +471,12 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "risc0-bigint2"
-version = "1.2.0-alpha.1"
-source = "git+https://github.com/risc0/risc0?rev=8fc8437633f08a66e0fbacce947f41d01b074774#8fc8437633f08a66e0fbacce947f41d01b074774"
+version = "1.3.0-alpha.1"
+source = "git+https://github.com/risc0/risc0?rev=c724cc14e316ff7bfae146bbbf2676515dac2a46#c724cc14e316ff7bfae146bbbf2676515dac2a46"
 dependencies = [
  "include_bytes_aligned",
  "num-bigint-dig",
+ "stability",
 ]
 
 [[package]]
@@ -644,6 +645,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0.184", optional = true, default-features = false, featur
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
 # risc0-bigint2 = { version = "1.2.0-rc.1", default-features = false, features = ["num-bigint-dig", "unstable"] }
-risc0-bigint2 = { git = "https://github.com/risc0/risc0", rev = "c724cc14e316ff7bfae146bbbf2676515dac2a46", default-features = false, features = ["num-bigint-dig", "unstable"] }
+risc0-bigint2 = { git = "https://github.com/risc0/risc0", rev = "ead10a316d6850a2a3e1332a00c7c432292313ab", default-features = false, features = ["num-bigint-dig", "unstable"] }
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ sha2 = { version = "0.10.6", optional = true, default-features = false, features
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-risc0-bigint2 = { git = "https://github.com/risc0/risc0", rev = "8fc8437633f08a66e0fbacce947f41d01b074774", default-features = false, features = ["num-bigint-dig"] }
+# risc0-bigint2 = { version = "1.2.0-rc.1", default-features = false, features = ["num-bigint-dig", "unstable"] }
+risc0-bigint2 = { git = "https://github.com/risc0/risc0", rev = "c724cc14e316ff7bfae146bbbf2676515dac2a46", default-features = false, features = ["num-bigint-dig", "unstable"] }
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ sha2 = { version = "0.10.6", optional = true, default-features = false, features
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-# risc0-bigint2 = { version = "1.2.0-rc.1", default-features = false, features = ["num-bigint-dig", "unstable"] }
-risc0-bigint2 = { git = "https://github.com/risc0/risc0", rev = "ead10a316d6850a2a3e1332a00c7c432292313ab", default-features = false, features = ["num-bigint-dig", "unstable"] }
+risc0-bigint2 = { version = "1.2.0", default-features = false, features = ["num-bigint-dig", "unstable"] }
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }


### PR DESCRIPTION
Draft PR until this is released into 1.2 -- as this is pointing to the git version