### PR TITLE
bigint2 acceleration patch to 0.9.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +470,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "risc0-bigint2"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c185a3bfaee681eed5bfac1440128184bf0b6544c345fb4d7bd4317c909fb"
+dependencies = [
+ "include_bytes_aligned",
+ "num-bigint-dig",
+ "stability",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.6"
 dependencies = [
@@ -481,6 +498,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rand_xorshift",
+ "risc0-bigint2",
  "serde",
  "serde_test",
  "sha1",
@@ -628,6 +646,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libm"
@@ -373,9 +379,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -408,9 +414,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -481,8 +487,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-zkvm-platform"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bbcc486222a0086d36244ae1f388cac1318270bca2dd23d77af2005d679edf"
+dependencies = [
+ "bytemuck",
+ "getrandom",
+ "stability",
+]
+
+[[package]]
 name = "rsa"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "base64ct",
  "const-oid",
@@ -499,6 +516,7 @@ dependencies = [
  "rand_core",
  "rand_xorshift",
  "risc0-bigint2",
+ "risc0-zkvm-platform",
  "serde",
  "serde_test",
  "sha1",
@@ -557,18 +575,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -666,9 +684,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ sha1 = { version = "0.10.5", optional = true, default-features = false, features
 sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
+[target.'cfg(target_os = "zkvm")'.dependencies]
+risc0-bigint2 = { version = "1.2.0", default-features = false, features = ["num-bigint-dig", "unstable"] }
+
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
 hex-literal = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,12 @@ sha1 = { version = "0.10.5", optional = true, default-features = false, features
 sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
 serde = { version = "1.0.184", optional = true, default-features = false, features = ["derive"] }
 
-[target.'cfg(target_os = "zkvm")'.dependencies]
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
 risc0-bigint2 = { version = "1.2.0", default-features = false, features = ["num-bigint-dig", "unstable"] }
 
 [dev-dependencies]
 base64ct = { version = "1", features = ["alloc"] }
 hex-literal = "0.4.1"
-proptest = "1"
 serde_test = "1.0.89"
 rand_xorshift = "0.3"
 rand_chacha = "0.3"
@@ -46,6 +45,13 @@ rand_core = { version = "0.6", default-features = false }
 sha1 = { version = "0.10.5", default-features = false, features = ["oid"] }
 sha2 = { version = "0.10.6", default-features = false, features = ["oid"] }
 sha3 = { version = "0.10.7", default-features = false, features = ["oid"] }
+
+[target.'cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))'.dev-dependencies]
+proptest = "1"
+
+[target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dev-dependencies]
+# getrandom impl for zkvm needed for tests
+risc0-zkvm-platform = { version = "1.2.0", features = ["getrandom", "unstable"] }
 
 [[bench]]
 name = "key"

--- a/src/pkcs1v15/signature.rs
+++ b/src/pkcs1v15/signature.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 pub use ::signature::{
     hazmat::{PrehashSigner, PrehashVerifier},
     DigestSigner, DigestVerifier, Error, Keypair, RandomizedDigestSigner, RandomizedSigner, Result,

--- a/src/pss.rs
+++ b/src/pss.rs
@@ -593,6 +593,8 @@ mod test {
         }
     }
 
+    // Ignore test in zkvm, it's too large (can test manually)
+    #[cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
     #[test]
     // Tests the corner case where the key is multiple of 8 + 1 bits long
     fn test_sign_and_verify_2049bit_key() {

--- a/src/pss/signature.rs
+++ b/src/pss/signature.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 pub use ::signature::{
     hazmat::{PrehashSigner, PrehashVerifier},
     DigestSigner, DigestVerifier, Error, Keypair, RandomizedDigestSigner, RandomizedSigner, Result,

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -1,4 +1,5 @@
 //! Property-based tests.
+#![cfg(not(all(target_os = "zkvm", target_arch = "riscv32")))]
 
 use proptest::prelude::*;
 use rand_chacha::ChaCha8Rng;


### PR DESCRIPTION
Squashed commits from 0.9.6 patch, but also includes the change for test config to enable using `cargo risczero test` such that future patches are easier to test. The tests are very slow because of the cipher based RNG and other slop in tests, but still easier than manually testing workflows

0.9.7 was released a few weeks ago, and just getting ahead of this patch for when it will be needed later